### PR TITLE
Fix #8 - Add missing 'use strict' to compiler

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -9,6 +9,8 @@
  *       2. Support includePaths option to minimize @import path length in each file
  */
 
+'use strict';
+
 var fs        = require('fs');
 var path      = require('path');
 var clonedeep = require('lodash.clonedeep');


### PR DESCRIPTION
Fix #8 : Add missing `use strict` to `lib/compiler.js`.