### PR TITLE
Add includePaths option

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,18 +85,14 @@ var gulpShopifySass = function gulpShopifySass (options, sync) {
       // we set the file path here so that libsass can correctly resolve import paths
       opts.file = file.path;
 
-      // TODO: add includePaths feature in options and relavent processer
-
       // Ensure file's parent directory in the include path
-      // if (opts.includePaths) {
-      //   if (typeof opts.includePaths === 'string') {
-      //     opts.includePaths = [opts.includePaths];
-      //   }
-      // } else {
-      //   opts.includePaths = [];
-      // }
-
-      // opts.includePaths.unshift(path.dirname(file.path));
+      if (opts.includePaths) {
+        if (typeof opts.includePaths === 'string') {
+          opts.includePaths = [opts.includePaths];
+        }
+      } else {
+        opts.includePaths = [];
+      }
 
       // TDDO: enable sync option once async render is done. Only support renderSync for now
       // if (sync === true) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -99,16 +99,16 @@ function checkFileExist (dir) {
   }
 }
 
-// @param:  dir                 full path and name
+// @param:  dirs                 dirs where to search the file
+// @param:  file                 @import file to search
 // @return: string | boolean
-function analyseDir (dir) {
+function analyseDirs (dirs, file) {
   // possible extension array
   const dirReg = new RegExp(/(.+\/)(.+)$/, 'g');
   const filenameReg = new RegExp(/^(\_)?(?:(.*(?=.scss))(.*)|(.*))$/, 'i');
 
   // split whole path into path the filename
-  let pathAndName = dirReg.exec(dir);
-
+  let pathAndName = dirReg.exec(file);
   const filepath = pathAndName[1] || '';
   let filename = pathAndName[2] || '';
 
@@ -122,8 +122,8 @@ function analyseDir (dir) {
   // move filename[4] to filename[2] is filename[2] is undefined
   filenameFrags[2] = filenameFrags[2] || filenameFrags[4];
 
-  let prefix = filenameFrags[1] ? [filenameFrags[1]] : ['', '_'];
-  let suffix = filenameFrags[3] ? [filenameFrags[3]] : ['.scss', '.scss.liquid'];
+  let prefixs = filenameFrags[1] ? [filenameFrags[1]] : ['', '_'];
+  let suffixs = filenameFrags[3] ? [filenameFrags[3]] : ['.scss', '.scss.liquid'];
 
   // remove original name, all index will reduce 1
   filenameFrags.shift();
@@ -132,20 +132,23 @@ function analyseDir (dir) {
   filenameFrags.pop()
 
   // check all possible combimations
-  for (let i in prefix) {
-    for (let j in suffix) {
-      filenameFrags[0] = prefix[i];
-      filenameFrags[2] = suffix[j];
-      filename = filenameFrags.join('');
-      pathAndName = path.join(filepath, filename);
+  let dir, fullPath;
+  for (let i_dir in dirs) {
+    for (let i_prefix in prefixs) {
+      for (let i_suffix in suffixs) {
+        filenameFrags[0] = prefixs[i_prefix];
+        filenameFrags[2] = suffixs[i_suffix];
+        filename = filenameFrags.join('');
+        fullPath = path.join(dirs[i_dir], filepath, filename);
 
-      if (checkFileExist(pathAndName)) {
-        return pathAndName;
+        if (checkFileExist(fullPath)) {
+          return fullPath;
+        }
       }
     }
   }
 
-  return new Error('File to import: "' + dir + '" not found.');
+  return new Error('Unable to import "' + file + '": file not found.');
 }
 
 
@@ -153,17 +156,20 @@ function importReplacer (options) {
 
   var rex = /@import\s*(?:(?:'([^']+)')|(?:"([^"]+)"))\s*;\s*$/gmi;
   var contents = options.data;
-  var dirname = path.dirname(options.file);
   var imports = {};
   var match;
+  var dirs = options.includePaths.slice(0);
+
+  // Add the current file path to where to search
+  if (typeof options.file !== 'undefined')
+    dirs.unshift(path.dirname(options.file));
 
   while(match = rex.exec(contents)) {
 
     // [1] single quotes
     // [2] double quotes
-    var importFile = path.join(dirname, (match[1] || match[2]));
-
-    const fileExistCheck = analyseDir(importFile);
+    var importFile = match[1] || match[2];
+    const fileExistCheck = analyseDirs(dirs, importFile);
 
     // if file exists, replace it
     if(fileExistCheck) {
@@ -178,7 +184,8 @@ function importReplacer (options) {
     let file = vfile.readSync(imports[imp]);
     let result = importReplacer({
       data: file.contents.toString(),
-      file: file.path
+      file: file.path,
+      includePaths: dirs
     });
 
     contents = contents.replace(new RegExp(imp, 'g'), result);


### PR DESCRIPTION
🚀  Add support for the `includePaths` node-sass option.

#### Changes:
- Uncomment  `includePaths` option management in index.
- `analyseDirs` take an array of directories as first argument, and search the file in all of these directories.

#### Other changes:
- Improve error message where a file is not found.
- Rename arrays of items to the plural form.

Closes #7