### PR TITLE
Fix #11 single filename import

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -103,7 +103,7 @@ function checkFileExist (dir) {
 // @return: string | boolean
 function analyseDir (dir) {
   // possible extension array
-  const dirReg = new RegExp(/(.+\/)(.+)$/, 'g');
+  const dirReg = new RegExp(/(.*\/)?(.+)$/, 'g');
   const filenameReg = new RegExp(/^(\_)?(?:(.*(?=.scss))(.*)|(.*))$/, 'i');
 
   // split whole path into path the filename


### PR DESCRIPTION
Allows to import a single filename without `/`.

See: https://regex101.com/r/xgXnV6/1