### PR TITLE
Fix #15 RegExp flags error for node 4.0

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -103,7 +103,7 @@ function checkFileExist (dir) {
 // @return: string | boolean
 function analyseDir (dir) {
   // possible extension array
-  const dirReg = new RegExp(/(.+\/)(.+)$/, 'g');
+  const dirReg = new RegExp(/(.*\/)?(.+)$/, 'g');
   const filenameReg = new RegExp(/^(\_)?(?:(.*(?=.scss))(.*)|(.*))$/, 'i');
 
   // split whole path into path the filename

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -103,8 +103,8 @@ function checkFileExist (dir) {
 // @return: string | boolean
 function analyseDir (dir) {
   // possible extension array
-  const dirReg = new RegExp(/(.*\/)?(.+)$/, 'g');
-  const filenameReg = new RegExp(/^(\_)?(?:(.*(?=.scss))(.*)|(.*))$/, 'i');
+  const dirReg = new RegExp(/(.*\/)?(.+)$/g);
+  const filenameReg = new RegExp(/^(\_)?(?:(.*(?=.scss))(.*)|(.*))$/i);
 
   // split whole path into path the filename
   let pathAndName = dirReg.exec(dir);


### PR DESCRIPTION
Fix #15 error ”can't supply flags when constructing one RegExp from another”.

**Changes**: Put the flags at the end of the RegExp instead, in `lib/compiler.js`

**See also**: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp

#### ⚠️  Require:
- [x] #12 