### PR TITLE
Add importer option

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -16,7 +16,7 @@ var fs        = require('fs');
 var path      = require('path');
 var clonedeep = require('lodash.clonedeep');
 var vfile     = require('vinyl-file');
-// var vinyl     = require('vinyl');
+
 /**
  * Get options
  *
@@ -156,7 +156,8 @@ function analyseDirs (dirs, file) {
 }
 
 // @param:  {object}  options
-// @return: {boolean} async
+// @param:  {boolean}  sync
+// @param:  {string}  prev
 function importReplacer (options, sync, prev) {
 
   var rex = /@import\s*(?:(?:'([^']+)')|(?:"([^"]+)"))\s*;\s*$/gmi;
@@ -190,14 +191,18 @@ function importReplacer (options, sync, prev) {
     }
   }
 
-  // replace @import with import file contents
+  // Replace @import with import file contents
+
   if (sync) {
+
     for(let filename in imports) {
       let importPath = imports[filename].import;
       let filePath = imports[filename].fullPath;
       let fileObj;
       let fileContents;
 
+      // If an importer is provided, get the new file name/content from it.
+      // In sync mode, only accept return.
       if (options.importer) {
         fileObj = options.importer(importPath, prev);
       }
@@ -210,6 +215,7 @@ function importReplacer (options, sync, prev) {
       else
         fileContents = vfile.readSync(fileObj.file);
 
+      // Do the same for the file just read
       let newFileContent = importReplacer(util._extend(options, {
         data: fileContents,
         file: fileObj.file,
@@ -223,6 +229,7 @@ function importReplacer (options, sync, prev) {
     }
 
     return contents;
+
   } else {
 
     let prevPromise = Promise.resolve(contents);
@@ -232,6 +239,8 @@ function importReplacer (options, sync, prev) {
       let importPath = imports[filename].import;
       prevPromise = prevPromise.then(contents => {
 
+        // If an importer is provided, get the new file name/content from it.
+        // In async mode, watch for both return and callback.
         if (options.importer) {
           var fileDatasPromise = new Promise ((resolve, reject) => {
             let ret = options.importer(importPath, prev, resolve);
@@ -268,6 +277,7 @@ function importReplacer (options, sync, prev) {
     }
 
     return prevPromise;
+
   }
 }
 
@@ -276,6 +286,7 @@ function importReplacer (options, sync, prev) {
  *
  * @param {Object}    opts
  * @param {Function}  cb
+ * @param {Function}  errorCb
  * @api public
  */
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -156,7 +156,7 @@ function analyseDirs (dirs, file) {
 
 // @param:  {object}  options
 // @return: {boolean} async
-function importReplacer (options, sync) {
+function importReplacer (options, sync, prev) {
 
   var rex = /@import\s*(?:(?:'([^']+)')|(?:"([^"]+)"))\s*;\s*$/gmi;
   var contents = options.data;
@@ -165,9 +165,12 @@ function importReplacer (options, sync) {
   var match;
   var dirs = options.includePaths.slice(0);
 
-  // Add the current file path to where to search
-  if (typeof options.file !== 'undefined')
+  if (typeof options.file !== 'undefined') {
+    // Add the current file path to where to search
     dirs.unshift(path.dirname(options.file));
+    // Define prev file as the current file path
+    var prev = options.file;
+  }
 
   while(match = rex.exec(contents)) {
 
@@ -175,7 +178,10 @@ function importReplacer (options, sync) {
     // [2] double quotes filename
     var importFile = match[1] || match[2];
 
-    const fileExistCheck = analyseDirs(dirs, importFile);
+    const fileExistCheck = {
+      import: importFile,
+      fullPath: analyseDirs(dirs, importFile)
+    };
 
     // if file exists, replace it
     if(fileExistCheck) {
@@ -193,7 +199,7 @@ function importReplacer (options, sync) {
         data: file.contents.toString(),
         file: file.path,
         includePaths: dirs
-      }, true);
+      }, true, filename);
 
       contents = contents.replace(new RegExp(filename, 'g'), function() {
         // http://stackoverflow.com/a/28103073
@@ -207,13 +213,35 @@ function importReplacer (options, sync) {
     let prevPromise = Promise.resolve(contents);
 
     for(let filename in imports) {
-      let filepath = imports[filename];
+      let filepath = imports[filename].fullPath;
+      let importPath = imports[filename].import;
       prevPromise = prevPromise.then(contents => {
-        return vfile.read(filepath).then(file => {
-          return importReplacer({
-            data: file.contents.toString(),
-            file: file.path,
-            includePaths: dirs
+
+        if (options.importer) {
+          var fileDatasPromise = new Promise ((resolve, reject) => {
+            let ret = options.importer(importPath, prev, resolve);
+            if (ret) {
+              resolve(ret);
+            }
+          });
+        }
+        else {
+          var fileDatasPromise = new Promise.resolve({file: filepath});
+        }
+
+        return fileDatasPromise.then(obj => {
+          if (obj.content)
+            var contentsPromise = Promise.resolve(obj.content);
+          else
+            var contentsPromise = vfile.read(obj.file).then(file => file.contents.toString());
+
+          return contentsPromise.then(contents => {
+            return importReplacer({
+              data: contents,
+              file: obj.file,
+              includePaths: dirs,
+              importer: options.importer
+            }, false, filename);
           });
         }).then(newFileContent => {
           return contents.replace(new RegExp(filename, 'g'), function() {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -192,13 +192,28 @@ function importReplacer (options, sync, prev) {
   // replace @import with import file contents
   if (sync) {
     for(let filename in imports) {
-      let filepath = imports[filename];
-      let file = vfile.readSync(filepath);
+      let importPath = imports[filename].import;
+      let filepath = imports[filename].fullPath;
+      let obj;
+      let fileContents;
+
+      if (options.importer) {
+        obj = options.importer(importPath, prev);
+      }
+      else {
+        obj = {file: filepath};
+      }
+
+      if (obj.content)
+        fileContents = obj.content;
+      else
+        fileContents = vfile.readSync(obj.file);
 
       let newFileContent = importReplacer({
-        data: file.contents.toString(),
-        file: file.path,
-        includePaths: dirs
+        data: fileContents,
+        file: obj.file,
+        includePaths: dirs,
+        importer: options.importer
       }, true, filename);
 
       contents = contents.replace(new RegExp(filename, 'g'), function() {
@@ -268,7 +283,7 @@ function importReplacer (options, sync, prev) {
 module.exports.render = function(opts, cb, errorCb) {
   var options = getOptions(opts, cb);
 
-  importReplacer(options).then(cb, errorCb);
+  importReplacer(options, false).then(cb, errorCb);
 };
 
 /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -193,28 +193,28 @@ function importReplacer (options, sync, prev) {
   if (sync) {
     for(let filename in imports) {
       let importPath = imports[filename].import;
-      let filepath = imports[filename].fullPath;
-      let obj;
+      let filePath = imports[filename].fullPath;
+      let fileObj;
       let fileContents;
 
       if (options.importer) {
-        obj = options.importer(importPath, prev);
+        fileObj = options.importer(importPath, prev);
       }
       else {
-        obj = {file: filepath};
+        fileObj = {file: filePath};
       }
 
-      if (obj.content)
-        fileContents = obj.content;
+      if (fileObj.content)
+        fileContents = fileObj.content;
       else
-        fileContents = vfile.readSync(obj.file);
+        fileContents = vfile.readSync(fileObj.file);
 
       let newFileContent = importReplacer({
         data: fileContents,
-        file: obj.file,
         includePaths: dirs,
         importer: options.importer
       }, true, filename);
+        file: fileObj.file,
 
       contents = contents.replace(new RegExp(filename, 'g'), function() {
         // http://stackoverflow.com/a/28103073
@@ -228,7 +228,7 @@ function importReplacer (options, sync, prev) {
     let prevPromise = Promise.resolve(contents);
 
     for(let filename in imports) {
-      let filepath = imports[filename].fullPath;
+      let filePath = imports[filename].fullPath;
       let importPath = imports[filename].import;
       prevPromise = prevPromise.then(contents => {
 
@@ -241,24 +241,24 @@ function importReplacer (options, sync, prev) {
           });
         }
         else {
-          var fileDatasPromise = Promise.resolve({file: filepath});
+          var fileDatasPromise = Promise.resolve({file: filePath});
         }
 
-        return fileDatasPromise.then(obj => {
-          let contents;
+        return fileDatasPromise.then(fileObj => {
+          let fileContents;
 
-          if (obj.content)
-            contents = obj.content;
+          if (fileObj.content)
+            fileContents = fileObj.content;
           else
-            contents = vfile.readSync(obj.file);
+            fileContents = vfile.readSync(fileObj.file);
 
           // Do the same for the file just read
           return importReplacer({
-            data: contents,
-            file: obj.file,
             includePaths: dirs,
             importer: options.importer
           }, false, filename);
+            data: fileContents,
+            file: fileObj.file,
         }).then(newFileContent => {
           return contents.replace(new RegExp(filename, 'g'), function() {
             // http://stackoverflow.com/a/28103073

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -230,19 +230,20 @@ function importReplacer (options, sync, prev) {
         }
 
         return fileDatasPromise.then(obj => {
-          if (obj.content)
-            var contentsPromise = Promise.resolve(obj.content);
-          else
-            var contentsPromise = vfile.read(obj.file).then(file => file.contents.toString());
+          let contents;
 
-          return contentsPromise.then(contents => {
-            return importReplacer({
-              data: contents,
-              file: obj.file,
-              includePaths: dirs,
-              importer: options.importer
-            }, false, filename);
-          });
+          if (obj.content)
+            contents = obj.content;
+          else
+            contents = vfile.readSync(obj.file);
+
+          // Do the same for the file just read
+          return importReplacer({
+            data: contents,
+            file: obj.file,
+            includePaths: dirs,
+            importer: options.importer
+          }, false, filename);
         }).then(newFileContent => {
           return contents.replace(new RegExp(filename, 'g'), function() {
             // http://stackoverflow.com/a/28103073

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var util      = require('util');
 var fs        = require('fs');
 var path      = require('path');
 var clonedeep = require('lodash.clonedeep');
@@ -209,12 +210,11 @@ function importReplacer (options, sync, prev) {
       else
         fileContents = vfile.readSync(fileObj.file);
 
-      let newFileContent = importReplacer({
+      let newFileContent = importReplacer(util._extend(options, {
         data: fileContents,
-        includePaths: dirs,
-        importer: options.importer
-      }, true, filename);
         file: fileObj.file,
+        includePaths: dirs
+      }), sync, filename);
 
       contents = contents.replace(new RegExp(filename, 'g'), function() {
         // http://stackoverflow.com/a/28103073
@@ -253,12 +253,11 @@ function importReplacer (options, sync, prev) {
             fileContents = vfile.readSync(fileObj.file);
 
           // Do the same for the file just read
-          return importReplacer({
-            includePaths: dirs,
-            importer: options.importer
-          }, false, filename);
+          return importReplacer(util._extend(options, {
             data: fileContents,
             file: fileObj.file,
+            includePaths: dirs
+          }), sync, filename);
         }).then(newFileContent => {
           return contents.replace(new RegExp(filename, 'g'), function() {
             // http://stackoverflow.com/a/28103073

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -226,7 +226,7 @@ function importReplacer (options, sync, prev) {
           });
         }
         else {
-          var fileDatasPromise = new Promise.resolve({file: filepath});
+          var fileDatasPromise = Promise.resolve({file: filepath});
         }
 
         return fileDatasPromise.then(obj => {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -290,7 +290,7 @@ function importReplacer (options, sync, prev) {
  * @api public
  */
 
-module.exports.render = function(opts, cb, errorCb) {
+function render(opts, cb, errorCb) {
   var options = getOptions(opts, cb);
 
   importReplacer(options, false).then(cb, errorCb);
@@ -303,7 +303,7 @@ module.exports.render = function(opts, cb, errorCb) {
  * @api public
  */
 
-module.exports.renderSync = function(options) {
+function renderSync(options) {
   // var options = getOptions(opts);
   // var importer = options.importer;
   // var status = importReplacer(options);
@@ -318,4 +318,9 @@ module.exports.renderSync = function(options) {
   // }
 
   // throw assign(new Error(), JSON.parse(result.error));
+};
+
+module.exports = {
+  render: render,
+  renderSync: renderSync
 };


### PR DESCRIPTION
#### Changes:
- Pass the previous path in `importReplacer`.
- Save the import path in `import` with the full path.
- Pass the previous path and current import path to the given importer `options.importer`.
- Update the promise flow to wait for the importer results (via return or callback).

#### ⚠️  [WIP]
- [ ] ~~Refactor sync management to avoid duplicating stuff.~~ No way !